### PR TITLE
Add a comment explaining why we disabled a test.

### DIFF
--- a/internal/ceres/CMakeLists.txt
+++ b/internal/ceres/CMakeLists.txt
@@ -289,6 +289,10 @@ if (BUILD_TESTING AND GFLAGS)
   ceres_test(block_random_access_diagonal_matrix)
   ceres_test(block_random_access_sparse_matrix)
   ceres_test(block_sparse_matrix)
+  # TODO(clalancette): there is a bug in the version of Eigen (3.3-beta1) in Ubuntu 16.04 on
+  # aarch64 that causes the bundle_adjustment tests to fail.  The solution is to upgrade to
+  # Eigen 3.3.4 or later.  However, since we aren't currently depending on bundle adjustment
+  # in ROS2 or cartographer, just comment out the test for now.
   #ceres_test(bundle_adjustment)
   ceres_test(c_api)
   ceres_test(canonical_views_clustering)


### PR DESCRIPTION
Change-Id: I05d3644595d9afe63a7916d33f111e623a6119e6
Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

(no CI; this is just a comment change)