### PR TITLE
Give credit to original authors in manifest

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -35,6 +35,7 @@
   <maintainer email="clalancette@openrobotics.org">
     Chris Lalancette
   </maintainer>
+  <author email="ceres-solver@googlegroups.com">The Ceres Solver Authors</author>
   <license>New BSD</license>
   <url type="website">http://ceres-solver.org/</url>
 


### PR DESCRIPTION
When replacing a maintainer we should create an author tag to credit the previous maintainer